### PR TITLE
force status bar redrawing, and disable water warp for fisheye

### DIFF
--- a/engine/NQ/sbar.c
+++ b/engine/NQ/sbar.c
@@ -912,8 +912,8 @@ Sbar_Draw(void)
     if (scr_con_current == vid.height)
 	return;			// console is full screen
 
-    if (vid.numpages && sb_updates >= vid.numpages)
-	return;
+    //if (vid.numpages && sb_updates >= vid.numpages)
+	//return;
 
     scr_copyeverything = 1;
 

--- a/engine/common/r_misc.c
+++ b/engine/common/r_misc.c
@@ -488,7 +488,11 @@ R_SetupFrame(void)
     r_viewleaf = Mod_PointInLeaf(cl.worldmodel, r_origin);
 
     r_dowarpold = r_dowarp;
-    r_dowarp = r_waterwarp.value && (r_viewleaf->contents <= CONTENTS_WATER);
+    if (fisheye_enabled) {
+      r_dowarp = 0;
+    } else {
+      r_dowarp = r_waterwarp.value && (r_viewleaf->contents <= CONTENTS_WATER);
+    }
 
     if ((r_dowarp != r_dowarpold) || r_viewchanged) {
 	if (r_dowarp) {


### PR DESCRIPTION
I remembered that I made an engine patch file here:
https://github.com/shaunlebron/blinky/blob/master/engine/fisheye.patch

it may not apply to latest tyrquake, but i was able to use context to fix two issues I noticed when playing.

works great, thanks 👍